### PR TITLE
Integration of Dart Extension Method.

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,4 +1,5 @@
 import 'package:translator/translator.dart';
+import 'package:translator/src/extension.dart';
 
 void main() async {
   final translator = GoogleTranslator();
@@ -11,6 +12,9 @@ void main() async {
           "Translated: " +
       s +
       "\n"));
+
+  // You can also call the extension method directly on the input
+  print('Translated: ${await input.translate(to: 'en')}');
 
   // for countries that default base URL doesn't work
   translator.baseUrl = "https://translate.google.cn/translate_a/single";

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -1,0 +1,7 @@
+import 'package:translator/src/google_translator.dart';
+
+extension StringExtension on String {
+
+    Future<String> translate({String from = 'auto', String to = 'en'}) async => await GoogleTranslator().translate(this, from: from, to: to);
+
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dev_dependencies:
   test: any
 
 environment:
-  #sdk: "2.0.0"
-  sdk: ">=2.0.0 <3.0.0"
+  #sdk: "2.6.0"
+  sdk: ">=2.6.0 <3.0.0"

--- a/test/test.dart
+++ b/test/test.dart
@@ -1,6 +1,7 @@
 import "package:test/test.dart";
 import 'package:translator/translator.dart';
 import 'package:http/http.dart' as http;
+import 'package:translator/src/extension.dart';
 
 void main() {
   test("Conection test: Is Google Translate API working?", () async {
@@ -54,4 +55,11 @@ void main() {
     var input = "The wisest go to the right";
     expect(await GoogleTranslator().translate(input, to: 'pt'), equals("O mais sábio vai para a direita"));
   });
+
+  test("Get the translation - using the extension method", () async {
+    var input = "The wisest go to the right";
+
+    expect(await input.translate(to: 'pt'), equals("O mais sábio vai para a direita"));
+  });
+
 }


### PR DESCRIPTION
Hi Gabriel,

Many thanks for this implementation. The translator works very seamlessly and I enjoy using it.

With the release of **Dart extension methods**, I thought that calling the `translate` method directly on the `String` as a `static method` might be another interesting way of referencing it.

What do you think?

It looks like this (without changing the current way it works):
```
final input = "Здравствуйте. Ты в порядке?";
final translation = await input.translate(to: 'en');
```

_N.B: Consequently, the Dart minimum version is increased to 2.6.0 (because of the Extension Methods Feature)_