### PR TITLE
Fix language is not supported issue.

### DIFF
--- a/lib/src/langs/language.dart
+++ b/lib/src/langs/language.dart
@@ -120,6 +120,7 @@ class LanguageList {
   };
 
   Language operator [](String code) {
+    code = code.toLowerCase();
     if (_langs.containsKey(code)) {
       return Language(code, _langs[code]);
     }


### PR DESCRIPTION
```dart
GoogleTranslator translator = new GoogleTranslator();
try {
  Translation translation =
      await translator.translate('你好', to: 'en');
} on Exception catch (e) {
  print(e);   // <=== zh-CN is not a supported language. is not a supported language.
}
```

Related with: #29 