### PR TITLE
⬆️ Upgrade http to 0.13.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A free and unlimited Google Translate API for Dart. You can use it 
 #author: Gabriel N. Pacheco <gabrielpacheco23@live.com>
 homepage: https://github.com/gabrielpacheco23/google-translator
 dependencies:
-  http: ^0.12.0
+  http: ^0.13.0
 
 dev_dependencies:
   test: any


### PR DESCRIPTION
Upgrade http library to 0.13.0 in order to fix some dependencies conflict when upgrading to null safety. #32 