### PR TITLE
Fixing baseURL replacement example

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -16,8 +16,8 @@ void main() async {
   // You can also call the extension method directly on the input
   print('Translated: ${await input.translate(to: 'en')}');
 
-  // For countries that default base URL doesn't work
-  translator.baseUrl = "translate.google.cn";
+  // You can also replace the default base URL for countries where the default one doesn't work
+  translator.baseUrl = "translate.google.com.hk";
   translator.translateAndPrint("This means 'testing' in chinese", to: 'zh-cn');
   //prints 这意味着用中文'测试'
 


### PR DESCRIPTION
Google has disabled Google Translate in parts of China, as this article states: https://techcrunch.com/2022/09/30/google-appears-to-have-disabled-google-translate-in-parts-of-china/

Therefore, an error 404 is received when trying to hit "translate.google.cn".

This PR replaces the URL "translate.google.cn" with "translate.google.com.hk" to exemplify how the default base URL can be replaced in the example repo.