### PR TITLE
accepting an optional http client

### DIFF
--- a/lib/src/google_translator.dart
+++ b/lib/src/google_translator.dart
@@ -2,6 +2,7 @@ library google_transl;
 
 import 'dart:async';
 import 'dart:convert' show jsonDecode;
+import 'dart:js_interop';
 import 'package:http/http.dart' as http;
 import './tokens/google_token_gen.dart';
 import './langs/language.dart';
@@ -19,8 +20,10 @@ class GoogleTranslator {
   final _tokenProvider = GoogleTokenGenerator();
   final _languageList = LanguageList();
   final ClientType client;
+  final http.Client httpClient;
 
-  GoogleTranslator({this.client = ClientType.siteGT});
+  GoogleTranslator({this.client = ClientType.siteGT, http.Client? httpClientArg})
+  : httpClient = httpClientArg.isNull ? http.Client() : httpClientArg!;
 
   /// Translates texts from specified language to another
   Future<Translation> translate(String sourceText,
@@ -48,7 +51,7 @@ class GoogleTranslator {
     };
 
     var url = Uri.https(_baseUrl, _path, parameters);
-    final data = await http.get(url);
+    final data = await httpClient.get(url);
 
     if (data.statusCode != 200) {
       throw http.ClientException('Error ${data.statusCode}: ${data.body}', url);


### PR DESCRIPTION
Users can supply an optional HTTP client in GoogleTranslator's constructor that the translator would use for all of its translation requests.