### PR TITLE
feat: :sparkles: add `TranslatedText` widget to use the package in the widget tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ translator.translateAndPrint("This means 'testing' in chinese", to: 'zh-cn');
 ```
 &nbsp;
 
+## TranslatedText Widget
+
+You can use the `TranslatedText` widget as a replacement for the `Text` widget to get the benefits of `translate()` method directly in the widget tree (UI Layer).
+
+```dart
+TranslatedText(
+  "Hello, World!",
+  loadingText: 'Loading...',
+  from: 'en',
+  to: 'ar',
+  style: TextStyle(fontSize: 20),
+)
+
+// prints مرحبا بالعالم!
+```
+&nbsp;
+
 # API
 For full API docs take a look at https://pub.dev/documentation/translator/latest/
 

--- a/lib/src/widgets/translated_text.dart
+++ b/lib/src/widgets/translated_text.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:translator/translator.dart';
+
+class TranslatedText extends StatefulWidget {
+  /// The text to be translated.
+  final String text;
+
+  /// The language code to translate from, default is 'auto' which means automatic language detection.
+  final String from;
+
+  /// The language code to translate to, default is 'en' which means English.
+  final String to;
+
+  /// A text to be displayed while the translation is in progress.
+  final String? loadingText;
+
+  /// The style to use for the text.
+  final TextStyle? style;
+
+  /// A Text widget that utilizes `GoogleTranslator.translate()` method to use the package directly in the UI as a replacement for `Text` widget.
+  const TranslatedText(
+    this.text, {
+    super.key,
+    this.from = 'auto',
+    this.to = 'en',
+    this.loadingText,
+    this.style,
+  });
+
+  @override
+  State<TranslatedText> createState() => _TranslatedTextState();
+}
+
+class _TranslatedTextState extends State<TranslatedText> {
+  String? _translatedText;
+
+  @override
+  void initState() {
+    GoogleTranslator()
+        .translate(widget.text, from: widget.from, to: widget.to)
+        .then((value) => setState(() => _translatedText = value.text));
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      _translatedText ?? widget.loadingText ?? widget.text,
+      style: widget.style,
+    );
+  }
+}

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -1,0 +1,1 @@
+export 'translated_text.dart';

--- a/lib/translator.dart
+++ b/lib/translator.dart
@@ -1,2 +1,3 @@
 export 'src/google_translator.dart';
 export 'src/extension.dart';
+export 'src/widgets/widgets.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,9 @@ description: A free and unlimited Google Translate API for Dart. You can use it 
 #author: Gabriel N. Pacheco <gabrielpacheco23@live.com>
 homepage: https://github.com/gabrielpacheco23/google-translator
 dependencies:
+  flutter:
+    sdk: flutter
+    
   http: ^1.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Hello there 👋🏻,

I just wanted to thank you for this great package! It's been really helpful for my Flutter projects 💪🏻💙

In this PR, I have added a widget called `TranslatedText` to utilize the `GoogleTranslator().translate()` method directly in the widget tree (UI Layer) as a replacement of the default `Text` widget ✅

I have also documented the widget with **Doc Comments** along with **README.md**  file 📃

I hope you find it helpful 🙏🏻
Thanks again for your hard work in the Flutter community 💙 🙏🏻